### PR TITLE
Use Debian version bullseye-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM debian:bullseye
-MAINTAINER Adrian Dvergsdal [atmoz.net]
+FROM debian:bullseye-slim
 
 # Steps done in one RUN layer:
 # - Install packages


### PR DESCRIPTION
## What & Why

To reduce the size of the container we want to use Debian bullseye-slim.